### PR TITLE
Add backtracking recursive formatter

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,0 +1,46 @@
+const typeConfig = require('./typeConfig');
+
+/* Backtracing recursive filler.
+ * merrillm sep10
+ *
+ * Please note that the Object implementation attempts to replace nested values
+ * before it actually calls a typefunc on itself. While this may seem trivial on
+ * first glance, it actually serves the purpose of allowing a user to throw a
+ * random "number" type into the argument position of a paramater for a higher scope.
+ * Hence, backtracing recursive.
+ *
+ * If this makes no sense ^ ask merrillm for a test case.
+ */
+function format(template) {
+
+    if (template === undefined || template === null) return template;   
+    
+    if (typeof template === "string" &&
+            template.startsWith('@') &&
+            typeConfig.isType(template.slice(1))) {
+        return typeConfig.getFunc(template.slice(1))({});
+    }
+    
+    // It is an Array
+    if (template instanceof Array) {
+        return template.map((x) => format(x));
+    }
+    
+    // It is an Object
+    if (typeof template === 'object') {
+        
+        for (key in template) {
+            template[key] = format(template[key]); 
+        }
+        
+        // Is this itself a filler type?
+        if (template.type) {
+            var funk = typeConfig.getFunc(template.type);
+            if (funk) return funk(template);
+        }
+    }
+    
+    return template;
+};
+
+module.exports = format;


### PR DESCRIPTION
I suggest we refactor all "format"-using functionalities (list, choose, object, etc.) to use a unified implementation of the formatting such as this. This way, we can make standards like whether or not a random number is supported as a value for the slope argument of a linear type.

This is one such implementation that I believe works quite well.
